### PR TITLE
Adding initial stats page: shows total number of messages

### DIFF
--- a/src/main/java/com/google/codeu/data/Datastore.java
+++ b/src/main/java/com/google/codeu/data/Datastore.java
@@ -19,6 +19,7 @@ package com.google.codeu.data;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.FilterOperator;
@@ -78,5 +79,12 @@ public class Datastore {
     }
 
     return messages;
+  }
+
+  /** Returns the total number of messages for all users. */
+  public int getTotalMessageCount(){
+    Query query = new Query("Message");
+    PreparedQuery results = datastore.prepare(query);
+    return results.countEntities(FetchOptions.Builder.withLimit(1000));
   }
 }

--- a/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
@@ -1,0 +1,41 @@
+package com.google.codeu.servlets;
+
+import java.io.IOException;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.google.codeu.data.Datastore;
+import com.google.gson.JsonObject;
+
+/**
+ * Handles fetching site statistics.
+ */
+@WebServlet("/stats")
+public class StatsPageServlet extends HttpServlet{
+
+  private Datastore datastore;
+
+  @Override
+  public void init() {
+    datastore = new Datastore();
+  }
+
+  /**
+   * Responds with site statistics in JSON.
+   */
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
+
+    response.setContentType("application/json");
+
+    int messageCount = datastore.getTotalMessageCount();
+
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("messageCount", messageCount);
+    response.getOutputStream().println(jsonObject.toString());
+  }
+}

--- a/src/main/webapp/stats.html
+++ b/src/main/webapp/stats.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Stats</title>
+  <link rel="stylesheet" href="/css/main.css">
+  
+  <script>
+    // Fetch stats and display them in the page.
+    function fetchStats(){
+      const url = '/stats';
+      fetch(url).then((response) => {
+        return response.json();
+      }).then((stats) => {
+        const statsContainer = document.getElementById('stats-container');
+        statsContainer.innerHTML = '';
+
+        const messageCountElement = buildStatElement('Message count: ' + stats.messageCount);
+        statsContainer.appendChild(messageCountElement);
+      });
+    }
+
+    function buildStatElement(statString){
+     const statElement = document.createElement('p');
+     statElement.appendChild(document.createTextNode(statString));
+     return statElement;
+    }
+
+    // Fetch data and populate the UI of the page.
+    function buildUI(){
+     fetchStats();
+    }
+  </script>
+</head>
+<body onload="buildUI()">
+<div id="content">
+  <h1>Site Statistics</h1>
+  <hr/>
+  <div id="stats-container">Loading...</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
This is just adding the code directly from https://sites.google.com/codeustudents.com/spring-2019/weeks-1-2-familiarization-projects/stats-page.  It adds `stats.html` and a corresponding `StatsPageServlet`.  It also adds a `getTotalMessageCount` to `Datastore`.

Test it with: `mvn appengine:devserver` and then visiting http://localhost:8080/stats.html.

More features and customizations will come in future Pull Requests.