### PR TITLE
Display 'User count' on stats page

### DIFF
--- a/src/main/java/com/google/codeu/data/Datastore.java
+++ b/src/main/java/com/google/codeu/data/Datastore.java
@@ -119,4 +119,23 @@ public class Datastore {
   
     return user;
   }
+
+  /** Returns the total number of users. */
+  public int getTotalUserCount() {
+    Set<String> allUsers = new HashSet<String>();
+
+    // Gets every user who has written an "about me" profile.
+    Query userQuery = new Query("User");
+    for (Entity entity : datastore.prepare(userQuery).asIterable()) {
+      allUsers.add((String) entity.getProperty("email"));
+    }
+
+    // Gets every user who has sent a message.
+    Query messageQuery = new Query("Message");
+    for (Entity entity : datastore.prepare(messageQuery).asIterable()) {
+      allUsers.add((String) entity.getProperty("user"));
+    }
+
+    return allUsers.size();
+  }
 }

--- a/src/main/java/com/google/codeu/data/Datastore.java
+++ b/src/main/java/com/google/codeu/data/Datastore.java
@@ -25,7 +25,9 @@ import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 /** Provides access to the data stored in Datastore. */
@@ -82,9 +84,21 @@ public class Datastore {
   }
 
   /** Returns the total number of messages for all users. */
-  public int getTotalMessageCount(){
+  public int getTotalMessageCount() {
     Query query = new Query("Message");
     PreparedQuery results = datastore.prepare(query);
     return results.countEntities(FetchOptions.Builder.withLimit(1000));
+  }
+
+  /** Returns the total number of users. */
+  public int getTotalUserCount() {
+    Query query = new Query("Message");
+    Set<String> allUsers = new HashSet<String>();
+    PreparedQuery results = datastore.prepare(query);
+    for (Entity entity : results.asIterable()) {
+        String user = (String) entity.getProperty("user");
+        allUsers.add(user);
+    }
+    return allUsers.size();
   }
 }

--- a/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
@@ -33,9 +33,11 @@ public class StatsPageServlet extends HttpServlet{
     response.setContentType("application/json");
 
     int messageCount = datastore.getTotalMessageCount();
+    int userCount = datastore.getTotalUserCount();
 
     JsonObject jsonObject = new JsonObject();
     jsonObject.addProperty("messageCount", messageCount);
+    jsonObject.addProperty("userCount", userCount);
     response.getOutputStream().println(jsonObject.toString());
   }
 }

--- a/src/main/webapp/stats.html
+++ b/src/main/webapp/stats.html
@@ -16,6 +16,8 @@
 
         const messageCountElement = buildStatElement('Message count: ' + stats.messageCount);
         statsContainer.appendChild(messageCountElement);
+        const userCountElement = buildStatElement('User count: ' + stats.userCount);
+        statsContainer.appendChild(userCountElement);
       });
     }
 


### PR DESCRIPTION
Adding the first custom feature to the stats page (i.e., the first thing that wasn't copied directly from the instructions.  This displays the total number of users in the system.  Note that since the system currently only stores messages, this is synonymous with displaying the number of users who have sent messages.

This can be tested by running `mvn appengine:devserver`, and then visiting http://localhost:8080/stats.html