### PR TITLE
OOP-ify Message Rewriting, Part 2: Add SequentialMessageTransformer

### DIFF
--- a/src/main/java/com/google/codeu/render/SequentialMessageTransformer.java
+++ b/src/main/java/com/google/codeu/render/SequentialMessageTransformer.java
@@ -1,0 +1,25 @@
+package com.google.codeu.render;
+
+import java.util.List;
+
+/**
+ * Chains together multiple MessageTransformer implementations.
+ *
+ * <p>This is an example of the Composite Pattern https://en.wikipedia.org/wiki/Composite_pattern
+ */
+public class SequentialMessageTransformer implements MessageTransformer {
+
+  private List<MessageTransformer> delegateMessageTransformers;
+
+  public SequentialMessageTransformer(List<MessageTransformer> delegateMessageTransformers) {
+    this.delegateMessageTransformers = delegateMessageTransformers;
+  }
+
+  @Override
+  public String transformText(String text) {
+    for (MessageTransformer messageTransformer : delegateMessageTransformers) {
+      text = messageTransformer.transformText(text);
+    }
+    return text;
+  }
+}

--- a/src/test/java/com/google/codeu/render/SequentialMessageTransformerTest.java
+++ b/src/test/java/com/google/codeu/render/SequentialMessageTransformerTest.java
@@ -1,0 +1,51 @@
+package com.google.codeu.render;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class SequentialMessageTransformerTest {
+
+  @Test
+  /** Tests that when there are no delegates, the input is return untransformed. */
+  public void testTransformTextNoDelegates() {
+    // Constructs the class under test.
+    MessageTransformer messageTransformer = new SequentialMessageTransformer(Arrays.asList());
+
+    assertEquals("some input", messageTransformer.transformText("some input"));
+  }
+
+  @Test
+  /** Tests when there is exactly one delegate, its output is returned. */
+  public void testTransformTextOneDelegate() {
+    MessageTransformer mockDelegate = Mockito.mock(MessageTransformer.class);
+    Mockito.when(mockDelegate.transformText("input text")).thenReturn("some mock output");
+
+    // Constructs the class under test.
+    MessageTransformer messageTransformer =
+        new SequentialMessageTransformer(Arrays.asList(mockDelegate));
+
+    assertEquals("some mock output", messageTransformer.transformText("input text"));
+  }
+
+  @Test
+  /** Tests a sequence of three delegates are run correctly. */
+  public void testTransformTextSequenceOfThree() {
+    MessageTransformer mockDelegate1 = Mockito.mock(MessageTransformer.class);
+    MessageTransformer mockDelegate2 = Mockito.mock(MessageTransformer.class);
+    MessageTransformer mockDelegate3 = Mockito.mock(MessageTransformer.class);
+
+    Mockito.when(mockDelegate1.transformText("an input text")).thenReturn("mock output 1");
+    Mockito.when(mockDelegate2.transformText("mock output 1")).thenReturn("mock output 2");
+    Mockito.when(mockDelegate3.transformText("mock output 2")).thenReturn("mock output 3");
+
+    // Constructs the class under test.
+    MessageTransformer messageTransformer =
+        new SequentialMessageTransformer(
+            Arrays.asList(mockDelegate1, mockDelegate2, mockDelegate3));
+
+    assertEquals("mock output 3", messageTransformer.transformText("an input text"));
+  }
+}


### PR DESCRIPTION
This class allows us to define a MessageTransformer that is actually wrapping multiple MessageTransformer implementations.  One big benefit is that each MessageTransformer implementation can be tested in isolation even though the website will use all of them.

See Part 1 in PR #31.

This can be reviewed, but **DO NOT MERGE** until #31 is merged.