### PR TITLE
Fixed some issues with regex, specifically with displaying captions

### DIFF
--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -50,12 +50,11 @@ public class MessageServlet extends HttpServlet {
     // Matches URL of an image file, with an optional caption. For example:
     //     [the google logo] http://www.google.com/images/logo.png
     // Matched URLs must end with one of: .png, .jpg, .gif
-    String regex = "(\\[([^\\]]+)\\]\\s)?(https?://(\\S+\\.\\S+)+/(.+\\.?)+\\.(png|jpe?g|gif))";    
+    String regex = "(\\[([^\\]]+)\\]\\s?)?(https?://(\\S+\\.\\S+)+/(.+\\.?)+\\.(png|jpe?g|gif))";    
     // Replaces the URL with the actual image. If a caption is given, it is printed below the image.
     String replacement = "<figure><img src=\"$3\" /> <figcaption>$2</figcaption></figure>";
     String text = message.getText();
     text = text.replaceAll(regex, replacement);
-    System.out.println(text);
     message.setText(text);
   }
 

--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -31,15 +31,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
 
-import com.google.appengine.api.blobstore.BlobstoreService;
-import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
-import com.google.appengine.api.blobstore.BlobKey;
-import com.google.appengine.api.images.ImagesService;
-import com.google.appengine.api.images.ImagesServiceFactory;
-import com.google.appengine.api.images.ServingUrlOptions;
-import java.util.Map;
-
-
 /** Handles fetching and saving {@link Message} instances. */
 @WebServlet("/messages")
 public class MessageServlet extends HttpServlet {
@@ -59,11 +50,12 @@ public class MessageServlet extends HttpServlet {
     // Matches URL of an image file, with an optional caption. For example:
     //     [the google logo] http://www.google.com/images/logo.png
     // Matched URLs must end with one of: .png, .jpg, .gif
-    String regex = "(\\[([^\\]]+)\\]\\s)?(https?://(\\S+\\.\\S+)+/(.+\\.?)+\\.(png|jpe?g|gif))";
+    String regex = "(\\[([^\\]]+)\\]\\s)?(https?://(\\S+\\.\\S+)+/(.+\\.?)+\\.(png|jpe?g|gif))";    
     // Replaces the URL with the actual image. If a caption is given, it is printed below the image.
     String replacement = "<figure><img src=\"$3\" /> <figcaption>$2</figcaption></figure>";
     String text = message.getText();
     text = text.replaceAll(regex, replacement);
+    System.out.println(text);
     message.setText(text);
   }
 
@@ -98,6 +90,7 @@ public class MessageServlet extends HttpServlet {
   /** Stores a new {@link Message}. */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
     UserService userService = UserServiceFactory.getUserService();
     if (!userService.isUserLoggedIn()) {
       response.sendRedirect("/index.html");
@@ -105,25 +98,10 @@ public class MessageServlet extends HttpServlet {
     }
 
     String user = userService.getCurrentUser().getEmail();
-    // System.out.println("text: " + request.getParameter("text"));
     String text = Jsoup.clean(request.getParameter("text"), Whitelist.none());
     String recipient = request.getParameter("recipient");
     
-    BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
-    Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
-    List<BlobKey> blobKeys = blobs.get("image");
-
     Message message = new Message(user, text, recipient);
-
-    if(blobKeys != null && !blobKeys.isEmpty()) {
-      BlobKey blobKey = blobKeys.get(0);
-      ImagesService imagesService = ImagesServiceFactory.getImagesService();
-      ServingUrlOptions options = ServingUrlOptions.Builder.withBlobKey(blobKey);
-      String imageUrl = imagesService.getServingUrl(options);
-      message.setImageUrl(imageUrl);
-    }
-
-
     datastore.storeMessage(message);
 
     response.sendRedirect("/user-page.html?user=" + recipient);

--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -50,12 +50,13 @@ public class MessageServlet extends HttpServlet {
     // Matches URL of an image file, with an optional caption. For example:
     //     [the google logo] http://www.google.com/images/logo.png
     // Matched URLs must end with one of: .png, .jpg, .gif
-    String regex = "(\\[.+\\])?\\s(https?://[\\S+\\.]+/([\\S+\\.?]+/?)+\\.(png|jpg|gif))";
+    String regex = "(\\[\\S+\\]\\s)?(https?://(\\S+\\.\\S+)+/(.+\\.?)+\\.(png|jpe?g|gif))";
     
     // Replaces the URL with the actual image. If a caption is given, it is printed below the image.
     String replacement = "<figure><img src=\"$2\" /> <figcaption>$1</figcaption></figure>";
     String text = message.getText();
     text = text.replaceAll(regex, replacement);
+    System.out.println(text);
     message.setText(text);
   }
 

--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -50,7 +50,7 @@ public class MessageServlet extends HttpServlet {
     // Matches URL of an image file, with an optional caption. For example:
     //     [the google logo] http://www.google.com/images/logo.png
     // Matched URLs must end with one of: .png, .jpg, .gif
-    String regex = "(\\[([^\\]]+)\\]\\s?)?(https?://(\\S+\\.\\S+)+/(.+\\.?)+\\.(png|jpe?g|gif))";    
+    String regex = "(\\[([^\\]]+)\\]\\s?)?(https?://(\\S+\\.\\S+)+/(.+\\.?)+\\.(png|jpe?g|gif))";
     // Replaces the URL with the actual image. If a caption is given, it is printed below the image.
     String replacement = "<figure><img src=\"$3\" /> <figcaption>$2</figcaption></figure>";
     String text = message.getText();

--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -50,7 +50,7 @@ public class MessageServlet extends HttpServlet {
     // Matches URL of an image file, with an optional caption. For example:
     //     [the google logo] http://www.google.com/images/logo.png
     // Matched URLs must end with one of: .png, .jpg, .gif
-    String regex = "(\\[([^\\]]+)\\]\\s?)?(https?://(\\S+\\.\\S+)+/(.+\\.?)+\\.(png|jpe?g|gif))";
+    String regex = "(\\[([^\\]]+)\\]\\s?)?(https?://(\\S+\\.\\S+)+/(\\S+\\.?)+\\.(png|jpe?g|gif))";
     // Replaces the URL with the actual image. If a caption is given, it is printed below the image.
     String replacement = "<figure><img src=\"$3\" /> <figcaption>$2</figcaption></figure>";
     String text = message.getText();

--- a/src/test/java/com/google/codeu/servlets/MessageServletTest.java
+++ b/src/test/java/com/google/codeu/servlets/MessageServletTest.java
@@ -31,5 +31,14 @@ public class MessageServletTest {
     runPrepareMessageForDisplayTest(
         "[This is the Google logo] http://www.google.com/images/logo.png!",
         "<figure><img src=\"http://www.google.com/images/logo.png\" /> <figcaption>This is the Google logo</figcaption></figure>!");
+    runPrepareMessageForDisplayTest("", "");
+    runPrepareMessageForDisplayTest("This is plain text.", "This is plain text.");
+    runPrepareMessageForDisplayTest("Check out this cool art. [Link.] https://pbs.twimg.com/media/D1ux_clUkAABe_P.png",
+        "Check out this cool art. <figure><img src=\"https://pbs.twimg.com/media/D1ux_clUkAABe_P.png\" /> <figcaption>Link.</figcaption></figure>");
+    runPrepareMessageForDisplayTest("[Fake caption 1.] [Peanut butter.] https://interfaithsanctuary.org/wp-content/uploads/2017/12/peanut-butter.jpg",
+        "[Fake caption 1.] <figure><img src=\"https://interfaithsanctuary.org/wp-content/uploads/2017/12/peanut-butter.jpg\" /> <figcaption>Peanut butter.</figcaption></figure>");
+    runPrepareMessageForDisplayTest("[Fake caption.] [Peanut butter.] https://interfaithsanctuary.org/wp-content/uploads/2017/12/peanut-butter.jpg "
+        + "https://pbs.twimg.com/media/D1ux_clUkAABe_P.png", "[Fake caption.] <figure><img src=\"https://interfaithsanctuary.org/wp-content/uploads/2017/12/peanut-butter.jpg\" /> <figcaption>Peanut butter.</figcaption></figure>"
+        + " <figure><img src=\"https://pbs.twimg.com/media/D1ux_clUkAABe_P.png\" /> <figcaption></figcaption></figure>");
   }
 }

--- a/src/test/java/com/google/codeu/servlets/MessageServletTest.java
+++ b/src/test/java/com/google/codeu/servlets/MessageServletTest.java
@@ -27,6 +27,9 @@ public class MessageServletTest {
   public void testPrepareMessageForDisplay() throws IOException, ServletException {
     runPrepareMessageForDisplayTest(
         "This is the Google logo http://www.google.com/images/logo.png!",
-        "This is the Google logo <img src=\"http://www.google.com/images/logo.png\" />!");
+        "This is the Google logo <figure><img src=\"http://www.google.com/images/logo.png\" /> <figcaption></figcaption></figure>!");
+    runPrepareMessageForDisplayTest(
+        "[This is the Google logo] http://www.google.com/images/logo.png!",
+        "<figure><img src=\"http://www.google.com/images/logo.png\" /> <figcaption>This is the Google logo</figcaption></figure>!");
   }
 }


### PR DESCRIPTION
- Updates to regex:
    - As long as the caption is contained by square brackets, the contents inside will become the caption in the HTML.
    - Image detection (?) portion of the regex can do both .jpg <i>and</i> .jpeg!
- Updates to replacement string:
    - Only the contents inside the square brackets will become the caption of the image. Had to update some of the pattern matching to do so.