### PR TITLE
User can query a singular tag for events

### DIFF
--- a/src/main/java/com/google/codeu/servlets/EventListServlet.java
+++ b/src/main/java/com/google/codeu/servlets/EventListServlet.java
@@ -4,6 +4,7 @@ import com.google.codeu.data.Datastore;
 import com.google.codeu.data.Event;
 import com.google.gson.Gson;
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.List;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -25,10 +26,19 @@ public class EventListServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     response.setContentType("application/json");
+    String tag = request.getParameter("tags");
 
     List<Event> events = datastore.getAllEvents();
+    if (tag != null) { 
+      Iterator it = events.iterator();
+      while (it.hasNext()) {
+        Event e = (Event) it.next();
+        if (!e.getDescription().contains(tag))
+          it.remove();
+      }
+    }
     Gson gson = new Gson();
     String json = gson.toJson(events);
-    response.getOutputStream().println(json);
+    response.getWriter().println(json);
   }
 }

--- a/src/main/java/com/google/codeu/servlets/EventListServlet.java
+++ b/src/main/java/com/google/codeu/servlets/EventListServlet.java
@@ -33,8 +33,9 @@ public class EventListServlet extends HttpServlet {
       Iterator it = events.iterator();
       while (it.hasNext()) {
         Event e = (Event) it.next();
-        if (!e.getDescription().contains(tag))
+        if (!e.getDescription().contains(tag)){
           it.remove();
+        }
       }
     }
     Gson gson = new Gson();

--- a/src/main/java/com/google/codeu/servlets/EventListServlet.java
+++ b/src/main/java/com/google/codeu/servlets/EventListServlet.java
@@ -33,7 +33,7 @@ public class EventListServlet extends HttpServlet {
       Iterator it = events.iterator();
       while (it.hasNext()) {
         Event e = (Event) it.next();
-        if (!e.getDescription().contains(tag)){
+        if (!e.getDescription().contains(tag)) {
           it.remove();
         }
       }

--- a/src/main/webapp/event-list.html
+++ b/src/main/webapp/event-list.html
@@ -9,7 +9,8 @@
     
   // Fetch messages and add them to the page.
   function fetchEvents(){
-    const url = "/event-list";
+    const urlParams = new URLSearchParams(location.search);
+    const url = "/event-list?" + urlParams;
     fetch(url).then((response) => {
       return response.json();
     }).then((events) => {


### PR DESCRIPTION
User can enter a link like `/event-list?tags=food` and the page will display a JSON that contains all the events that have "food" as its substring.

(Some issues that may arise is if a string contains "food" -- something like "dwaojnlnfoodkdlwa" -- the event will still be displayed in the JSON.)