### PR TITLE
Strengthened tag querying

### DIFF
--- a/src/main/java/com/google/codeu/servlets/EventListServlet.java
+++ b/src/main/java/com/google/codeu/servlets/EventListServlet.java
@@ -10,6 +10,8 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /** Servlet that will initiate whenever a user goes to the event list page. */
 @WebServlet("/event-list")
@@ -33,6 +35,15 @@ public class EventListServlet extends HttpServlet {
       Iterator it = events.iterator();
       while (it.hasNext()) {
         Event e = (Event) it.next();
+        // String description = e.getDescription();
+        // String regex = "(#\\w+)";
+
+        // Pattern p = Pattern.compile(regex);
+        // Matcher m = p.matcher(description);
+        // while (m.find()) {
+        //   String hashtag = m.group(1);
+        //   System.out.println("hash: " + hashtag);
+        // }
         if (!e.getDescription().contains(tag)) {
           it.remove();
         }

--- a/src/main/java/com/google/codeu/servlets/EventListServlet.java
+++ b/src/main/java/com/google/codeu/servlets/EventListServlet.java
@@ -35,16 +35,24 @@ public class EventListServlet extends HttpServlet {
       Iterator it = events.iterator();
       while (it.hasNext()) {
         Event e = (Event) it.next();
-        // String description = e.getDescription();
-        // String regex = "(#\\w+)";
+        String description = e.getDescription();
+        String regex = "(#\\w+)";
 
-        // Pattern p = Pattern.compile(regex);
-        // Matcher m = p.matcher(description);
-        // while (m.find()) {
-        //   String hashtag = m.group(1);
-        //   System.out.println("hash: " + hashtag);
-        // }
-        if (!e.getDescription().contains(tag)) {
+        // Retrieve all hashtags in the description
+        Pattern p = Pattern.compile(regex);
+        Matcher m = p.matcher(description);
+        boolean hashtagExists = false;
+
+        // Iterate through all hashtag terms and only remove
+        // events that do not have the hashtag in its description.
+        while (m.find()) {
+          String hashtag = m.group(1);
+          if (hashtag.substring(1).equals(tag)) {
+            hashtagExists = true;
+            break;
+          }
+        }
+        if (!hashtagExists) {
           it.remove();
         }
       }

--- a/src/main/java/com/google/codeu/servlets/EventListServlet.java
+++ b/src/main/java/com/google/codeu/servlets/EventListServlet.java
@@ -6,12 +6,12 @@ import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /** Servlet that will initiate whenever a user goes to the event list page. */
 @WebServlet("/event-list")

--- a/src/main/webapp/js/event-div-creator.js
+++ b/src/main/webapp/js/event-div-creator.js
@@ -1,6 +1,5 @@
 // Fetch messages and add them to the page.
 function fetchEvents(){
-  const url = "/event-list";
   const urlParams = new URLSearchParams(location.search); 
   const url = "/event-list?" + urlParams;
   fetch(url).then((response) => {

--- a/src/main/webapp/js/event-div-creator.js
+++ b/src/main/webapp/js/event-div-creator.js
@@ -1,6 +1,8 @@
 // Fetch messages and add them to the page.
 function fetchEvents(){
   const url = "/event-list";
+  const urlParams = new URLSearchParams(location.search); 
+  const url = "/event-list?" + urlParams;
   fetch(url).then((response) => {
     return response.json();
   }).then((events) => {


### PR DESCRIPTION
Events that have the exact query in its hashtags will show up when querying.

For example, `/event-list.html?tags=food` will only display the events that have `#food` in it. Before, the querying showed any event that included the word "food" in the description, whether or not it was preceded by a hashtag.